### PR TITLE
Fix Supabase URL

### DIFF
--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,7 +2,7 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https.quafjhdptjaewyomkzdf.supabase.co";
+const SUPABASE_URL = "https://quafjhdptjaewyomkzdf.supabase.co";
 const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InF1YWZqaGRwdGphZXd5b21remRmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM2NDYzNjUsImV4cCI6MjA2OTIyMjM2NX0.FslyVB5xZOViHf4GYsFdTZH8Xag5vX9eQOm7moDW6uI";
 
 // Import the supabase client like this:


### PR DESCRIPTION
## Summary
- fix invalid Supabase URL in the generated client file

## Testing
- `npm run lint` *(fails: eslint not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68868dc6b2788332b871659f8a976035