### PR TITLE
Add demo edge function and admin SQL seed

### DIFF
--- a/src/utils/supabase-schema.sql
+++ b/src/utils/supabase-schema.sql
@@ -79,6 +79,13 @@ CREATE TABLE public.exchange_rates (
   UNIQUE(from_currency, to_currency)
 );
 
+-- Simple table to demonstrate storing admin credentials
+CREATE TABLE public.admin_users (
+  id serial PRIMARY KEY,
+  username text NOT NULL UNIQUE,
+  password text NOT NULL
+);
+
 -- Enable Row Level Security
 ALTER TABLE public.user_settings ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.incomes ENABLE ROW LEVEL SECURITY;
@@ -162,5 +169,9 @@ CREATE POLICY exchange_rates_update ON public.exchange_rates
   FOR UPDATE USING (auth.role() = 'authenticated');
 
 -- Insert initial exchange rate
-INSERT INTO public.exchange_rates (from_currency, to_currency, rate) 
+INSERT INTO public.exchange_rates (from_currency, to_currency, rate)
 VALUES ('USD', 'TRY', 38.76);
+
+-- Insert admin user credentials for demonstration purposes
+INSERT INTO public.admin_users (username, password)
+VALUES ('admin', '123');

--- a/supabase/functions/hello-world/index.ts
+++ b/supabase/functions/hello-world/index.ts
@@ -1,0 +1,20 @@
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type"
+};
+
+serve((req) => {
+  if (req.method === "OPTIONS") {
+    return new Response("ok", { headers: corsHeaders });
+  }
+
+  return new Response(
+    JSON.stringify({ message: "Hello from Supabase Edge Functions!" }),
+    {
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+      status: 200
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add a minimal `hello-world` Supabase Edge Function
- add example table and seed for an admin user in Supabase SQL schema

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(fails: missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688691be35a4833290e1fecb7bb97c26