### PR TITLE
Fix Supabase context usage

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
-import { createRoot } from 'react-dom/client'
-import App from './App.tsx'
-import './index.css'
+import { createRoot } from 'react-dom/client';
+import App from './App.tsx';
+import './index.css';
+import { SupabaseProvider } from '@/contexts/SupabaseContext';
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById('root')!).render(
+  <SupabaseProvider>
+    <App />
+  </SupabaseProvider>
+);


### PR DESCRIPTION
## Summary
- wrap root render with `SupabaseProvider`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run type-check` *(not run due to prior failure)*
- `npm run build` *(not run due to prior failure)*


------
https://chatgpt.com/codex/tasks/task_e_688696df5a0483328c512ed047167af1